### PR TITLE
Fix missing lab assets by enforcing trailing slash redirects

### DIFF
--- a/app/.htaccess
+++ b/app/.htaccess
@@ -1,4 +1,6 @@
 RewriteEngine On
+RewriteCond %{REQUEST_FILENAME} -d
+RewriteRule ^(.+[^/])$ $1/ [L,R=301]
 RewriteRule ^(lab)($|/) - [L]
 RewriteRule ^dashboard/?$ dashboard/index.php [L,QSA]
 RewriteRule ^dashboard/(.*)$ dashboard/index.php [L,QSA]


### PR DESCRIPTION
## Summary
- redirect requests for lab directories without a trailing slash to their canonical slash form
- ensure lab asset URLs resolve correctly regardless of how the lab page is opened

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68dd616d64f083268f286f9d7f48fec3